### PR TITLE
Fix handling other struct field types

### DIFF
--- a/configs/.cspell.json
+++ b/configs/.cspell.json
@@ -35,6 +35,7 @@
     "gomega",
     "gostd",
     "govet",
+    "maintidx",
     "megalinter",
     "nolint",
     "nosnakecase",

--- a/configs/.cspell.json
+++ b/configs/.cspell.json
@@ -24,6 +24,7 @@
     "exportloopref",
     "forcetypeassert",
     "funlen",
+    "goconst",
     "ifshort",
     "interfacer",
     "intrange",

--- a/configs/.gitleaks.toml
+++ b/configs/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+# password is used in test data
+regexes = [
+  '''password''',
+]

--- a/configs/.mega-linter.yml
+++ b/configs/.mega-linter.yml
@@ -26,4 +26,5 @@ POST_COMMANDS:
 # linter configurations
 COPYPASTE_JSCPD_CONFIG_FILE: ./configs/.jscpd.json
 GO_GOLANGCI_LINT_CONFIG_FILE: ./configs/.golangci.yml
+REPOSITORY_GITLEAKS_CONFIG_FILE: ./configs/.gitleaks.toml
 SPELL_CSPELL_CONFIG_FILE: ./configs/.cspell.json

--- a/configs/.mega-linter.yml
+++ b/configs/.mega-linter.yml
@@ -27,4 +27,5 @@ POST_COMMANDS:
 COPYPASTE_JSCPD_CONFIG_FILE: ./configs/.jscpd.json
 GO_GOLANGCI_LINT_CONFIG_FILE: ./configs/.golangci.yml
 REPOSITORY_GITLEAKS_CONFIG_FILE: ./configs/.gitleaks.toml
+REPOSITORY_TRIVY_CONFIG_FILE: ./configs/.trivy.yml
 SPELL_CSPELL_CONFIG_FILE: ./configs/.cspell.json

--- a/configs/.trivy.yml
+++ b/configs/.trivy.yml
@@ -1,0 +1,3 @@
+scan:
+  skip-dirs:
+    - megalinter-reports

--- a/examples_test.go
+++ b/examples_test.go
@@ -13,6 +13,7 @@ func ExampleRedactWithAllowList() {
 		Password string
 		Key      []byte
 		IsAdmin  bool
+		Groups   []string
 	}
 
 	testUser := user{
@@ -20,23 +21,29 @@ func ExampleRedactWithAllowList() {
 		Password: "super secret",
 		Key:      []byte("another secret"),
 		IsAdmin:  true,
+		Groups:   []string{"users"},
 	}
+	// RedactWithAllowList redacts all strings and []byte by default
+	defaultRedactedUser := rere.RedactWithAllowList(testUser, nil)
+	fmt.Printf("default redacted value: %+v\n", defaultRedactedUser)
+
 	// allowList is matched against case insensitively
-	allowList := []string{"username"}
+	allowList := []string{"username", "groups"}
 	redactedUser := rere.RedactWithAllowList(testUser, allowList)
-	fmt.Printf("redacted string field value: %+v\n", redactedUser)
+	fmt.Printf("redacted value with allow list: %+v\n", redactedUser)
 
 	// RedactWithAllowList will not modify the original value - perfect for logging
 	// RedactWithAllowList does not require a pointer. This is just to help further exemplify the point
 	// that the original value is left unchanged.
 	redactedUserPointer := rere.RedactWithAllowList(&testUser, allowList)
-	fmt.Printf("redacted string field value on pointer to struct: %+v\n", *redactedUserPointer)
+	fmt.Printf("redacted pointer value: %+v\n", *redactedUserPointer)
 	fmt.Printf("original value left unchanged: %+v\n", testUser)
 
 	//nolint:lll // ignore long line length for example output
-	// Output: redacted string field value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
-	// redacted string field value on pointer to struct: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
-	// original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true}
+	// Output: default redacted value: {Username:REDACTED Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[REDACTED]}
+	// redacted value with allow list: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+	// redacted pointer value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+	// original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true Groups:[users]}
 }
 
 func ExampleRedactWithDenyList() {
@@ -46,6 +53,7 @@ func ExampleRedactWithDenyList() {
 		Password string
 		Key      []byte
 		IsAdmin  bool
+		Groups   []string
 	}
 
 	testUser := user{
@@ -53,21 +61,27 @@ func ExampleRedactWithDenyList() {
 		Password: "super secret",
 		Key:      []byte("another secret"),
 		IsAdmin:  true,
+		Groups:   []string{"users"},
 	}
+	// RedactWithDenyList redacts nothing by default
+	defaultRedactedUser := rere.RedactWithDenyList(testUser, nil)
+	fmt.Printf("default denied value: %+v\n", defaultRedactedUser)
+
 	// denyList is matched against case insensitively
 	denyList := []string{"password", "Key"}
 	redactedUser := rere.RedactWithDenyList(testUser, denyList)
-	fmt.Printf("redacted string field value: %+v\n", redactedUser)
+	fmt.Printf("redacted value with deny list: %+v\n", redactedUser)
 
 	// RedactWithDenyList will not modify the original value - perfect for logging
 	// RedactWithDenyList does not require a pointer. This is just to help further exemplify the point
 	// that the original value is left unchanged.
 	redactedUserPointer := rere.RedactWithDenyList(&testUser, denyList)
-	fmt.Printf("redacted string field value on pointer to struct: %+v\n", *redactedUserPointer)
+	fmt.Printf("redacted pointer value: %+v\n", *redactedUserPointer)
 	fmt.Printf("original value left unchanged: %+v\n", testUser)
 
 	//nolint:lll // ignore long line length for example output
-	// Output: redacted string field value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
-	// redacted string field value on pointer to struct: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
-	// original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true}
+	// Output: default denied value: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true Groups:[users]}
+	// redacted value with deny list: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+	// redacted pointer value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+	// original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true Groups:[users]}
 }

--- a/readme.md
+++ b/readme.md
@@ -39,35 +39,44 @@ read the warning in [Example using a deny list](#example-using-a-deny-list) for 
 An example of typical usage of `rere.RedactWithAllowList` is:
 
 ```go
-func main() {
+func ExampleRedactWithAllowList() {
  // RedactWithAllowList will redact string and byte slice/array field values for field names not found in allow list
  type user struct {
   Username string
   Password string
   Key      []byte
   IsAdmin  bool
+  Groups   []string
  }
- u := user{
+
+ testUser := user{
   Username: "dustin",
   Password: "super secret",
   Key:      []byte("another secret"),
   IsAdmin:  true,
+  Groups:   []string{"users"},
  }
+ // RedactWithAllowList redacts all strings and []byte by default
+ defaultRedactedUser := rere.RedactWithAllowList(testUser, nil)
+ fmt.Printf("default redacted value: %+v\n", defaultRedactedUser)
+
  // allowList is matched against case insensitively
- allowList := []string{"Username"}
- redactedUser := rere.RedactWithAllowList(u, allowList)
- fmt.Printf("redacted string field value: %+v\n", redactedUser)
+ allowList := []string{"username", "groups"}
+ redactedUser := rere.RedactWithAllowList(testUser, allowList)
+ fmt.Printf("redacted value with allow list: %+v\n", redactedUser)
 
  // RedactWithAllowList will not modify the original value - perfect for logging
  // RedactWithAllowList does not require a pointer. This is just to help further exemplify the point
  // that the original value is left unchanged.
- redactedUserPointer := rere.RedactWithAllowList(&u, allowList)
- fmt.Printf("redacted string field value on pointer to struct: %+v\n", *redactedUserPointer)
- fmt.Printf("original value left unchanged: %+v\n", u)
+ redactedUserPointer := rere.RedactWithAllowList(&testUser, allowList)
+ fmt.Printf("redacted pointer value: %+v\n", *redactedUserPointer)
+ fmt.Printf("original value left unchanged: %+v\n", testUser)
 
- // Output: redacted string field value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
- // redacted string field value on pointer to struct: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
- // original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true}
+ //nolint:lll // ignore long line length for example output
+ // Output: default redacted value: {Username:REDACTED Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[REDACTED]}
+ // redacted value with allow list: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+ // redacted pointer value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+ // original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true Groups:[users]}
 }
 ```
 
@@ -76,35 +85,45 @@ func main() {
 An example of typical usage of `rere.RedactWithDenyList` is:
 
 ```go
-func main() {
+func ExampleRedactWithDenyList() {
  // RedactWithDenyList will redact string and byte slice/array field values for field names found in deny list
  type user struct {
   Username string
   Password string
   Key      []byte
   IsAdmin  bool
+  Groups   []string
  }
- u := user{
+
+ testUser := user{
   Username: "dustin",
   Password: "super secret",
   Key:      []byte("another secret"),
   IsAdmin:  true,
+  Groups:   []string{"users"},
  }
+ // RedactWithDenyList redacts nothing by default
+ defaultRedactedUser := rere.RedactWithDenyList(testUser, nil)
+ fmt.Printf("default denied value: %+v\n", defaultRedactedUser)
+
  // denyList is matched against case insensitively
- denyList := []string{"Password", "Key"}
- redactedUser := rere.RedactWithDenyList(u, denyList)
- fmt.Printf("redacted string field value: %+v\n", redactedUser)
+ denyList := []string{"password", "Key"}
+ redactedUser := rere.RedactWithDenyList(testUser, denyList)
+ fmt.Printf("redacted value with deny list: %+v\n", redactedUser)
 
  // RedactWithDenyList will not modify the original value - perfect for logging
  // RedactWithDenyList does not require a pointer. This is just to help further exemplify the point
  // that the original value is left unchanged.
- redactedUserPointer := rere.RedactWithDenyList(&u, denyList)
- fmt.Printf("redacted string field value on pointer to struct: %+v\n", *redactedUserPointer)
- fmt.Printf("original value left unchanged: %+v\n", u)
+ redactedUserPointer := rere.RedactWithDenyList(&testUser, denyList)
+ fmt.Printf("redacted pointer value: %+v\n", *redactedUserPointer)
+ fmt.Printf("original value left unchanged: %+v\n", testUser)
 
- // Output: redacted string field value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
- // redacted string field value on pointer to struct: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true}
- // original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true}
+ //nolint:lll // ignore long line length for example output
+ // Output: default denied value: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true Groups:[users]}
+ // redacted value with deny list: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+ // redacted pointer value: {Username:dustin Password:REDACTED Key:[82 69 68 65 67 84 69 68] IsAdmin:true Groups:[users]}
+ // original value left unchanged: {Username:dustin Password:super secret Key:[97 110 111 116 104 101 114 32 115 101 99 114 101 116] IsAdmin:true Groups:[users]}
+}
 ```
 
 **NOTE**: It is **STRONGLY** discouraged to use `RedactWithDenyList` in production code, as it is easy to accidentally miss redacting sensitive information.

--- a/rere.go
+++ b/rere.go
@@ -29,9 +29,9 @@ const (
 //
 // RedactWithAllowList will loop through elements in slices and arrays to redact using above approach.
 //
-// If RedactWithAllowList is provided a string or []byte value then it will redact the value with "REDACTED",
-// regardless of the allow list. The same is true when looping through types like []string when the field
-// name is not in the allow list.
+// If RedactWithAllowList is directly provided a string or []byte value then it will redact the value with "REDACTED",
+// regardless of the allow list. If a field or key value is a []string then the slice will be redacted if the field
+// or key name does not appear in the allow list.
 func RedactWithAllowList[T any](value T, allowList []string) T {
 	// create a deep copy of the provided value, so original value is not modified
 	//nolint:forcetypeassert // the type is correct and if not then reprint is broken and will be caught by unit tests
@@ -55,9 +55,9 @@ func RedactWithAllowList[T any](value T, allowList []string) T {
 //
 // RedactWithDenyList will loop through elements in slices and arrays to redact using above approach.
 //
-// If RedactWithDenyList is provided a string or []byte value then it will redact the value with "REDACTED",
-// regardless of the deny list. The same is true when looping through types like []string when the field
-// name is in the deny list.
+// If RedactWithDenyList is directly provided a string or []byte value then it will not redact the value,
+// regardless of the deny list. If a field or key value is a []string then the slice will be redacted if the field
+// or key name does appear in the deny list.
 //
 // NOTE: It is *STRONGLY* discouraged to use RedactWithDenyList in production code, as it is easy to accidentally
 // miss redacting sensitive information.
@@ -175,10 +175,10 @@ func redact(fieldKeyName string, value reflect.Value, mode redactMode, fieldKeyN
 }
 
 func shouldRedact(fieldKeyName string, mode redactMode, fieldKeyNameList []string) bool {
-	// redact when no field name
+	// redact when no field name and in allow mode, otherwise do not redact when in deny mode
 	// no field name means user provided a string or we're looping through a []string
 	if fieldKeyName == "" {
-		return true
+		return mode == allow
 	}
 
 	// skip redacting fields in the allow list when in allow mode

--- a/rere_test.go
+++ b/rere_test.go
@@ -19,6 +19,7 @@ type structWithRedactedFields struct {
 	password  string
 	username  string
 	byteSlice []byte
+	stringPtr *string
 }
 
 type structWithByteField struct {
@@ -47,7 +48,7 @@ type structWithInterface struct {
 	password any
 }
 
-//nolint:funlen // I'm okay with test functions with several statements of test data
+//nolint:funlen,maintidx // I'm okay with test functions with several statements of test data
 func TestRedactWithAllowList(t *testing.T) {
 	t.Parallel()
 
@@ -75,6 +76,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				Password:  "hunter2",
 				password:  "*****",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 			allowList: nil,
 			output: structWithRedactedFields{
@@ -83,6 +85,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				Password:  "REDACTED",
 				password:  "REDACTED",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 		},
 		{
@@ -93,6 +96,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				Password:  "password",
 				password:  "password",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 			allowList: nil,
 			output: &structWithRedactedFields{
@@ -101,6 +105,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				Password:  "REDACTED",
 				password:  "REDACTED",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 		},
 		{
@@ -111,6 +116,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				Password:  "",
 				password:  "",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 			allowList: nil,
 			output: structWithRedactedFields{
@@ -119,6 +125,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				Password:  "",
 				password:  "",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 		},
 		{
@@ -164,6 +171,7 @@ func TestRedactWithAllowList(t *testing.T) {
 					Password:  "password",
 					password:  "REDACTED",
 					byteSlice: nil,
+					stringPtr: nil,
 				},
 			},
 			allowList: nil,
@@ -174,6 +182,7 @@ func TestRedactWithAllowList(t *testing.T) {
 					Password:  "REDACTED",
 					password:  "REDACTED",
 					byteSlice: nil,
+					stringPtr: nil,
 				},
 			},
 		},
@@ -212,6 +221,7 @@ func TestRedactWithAllowList(t *testing.T) {
 							Password:  "password",
 							password:  "password",
 							byteSlice: nil,
+							stringPtr: nil,
 						},
 					},
 				},
@@ -226,6 +236,7 @@ func TestRedactWithAllowList(t *testing.T) {
 							Password:  "REDACTED",
 							password:  "REDACTED",
 							byteSlice: nil,
+							stringPtr: nil,
 						},
 					},
 				},
@@ -271,6 +282,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				password:  "",
 				username:  "dustin",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 			allowList: []string{"Username"},
 			output: structWithRedactedFields{
@@ -279,6 +291,7 @@ func TestRedactWithAllowList(t *testing.T) {
 				password:  "",
 				username:  "dustin",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 		},
 		{
@@ -304,6 +317,7 @@ func TestRedactWithAllowList(t *testing.T) {
 					Password:  "password",
 					password:  "password",
 					byteSlice: []byte("password"),
+					stringPtr: nil,
 				},
 			},
 			allowList: []string{"username", "byteslice"},
@@ -314,6 +328,7 @@ func TestRedactWithAllowList(t *testing.T) {
 					Password:  "REDACTED",
 					password:  "REDACTED",
 					byteSlice: []byte("password"),
+					stringPtr: nil,
 				},
 			},
 		},
@@ -366,6 +381,7 @@ func TestRedactWithDenyList(t *testing.T) {
 				Password:  "password",
 				password:  "password",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 			denyList: []string{"Password"},
 			output: structWithRedactedFields{
@@ -374,6 +390,7 @@ func TestRedactWithDenyList(t *testing.T) {
 				Password:  "REDACTED",
 				password:  "REDACTED",
 				byteSlice: nil,
+				stringPtr: nil,
 			},
 		},
 		{
@@ -399,6 +416,11 @@ func TestRedactWithDenyList(t *testing.T) {
 					Password:  "password",
 					password:  "password",
 					byteSlice: []byte("password"),
+					stringPtr: func() *string {
+						password := "password"
+
+						return &password
+					}(),
 				},
 			},
 			denyList: []string{"password"},
@@ -409,6 +431,11 @@ func TestRedactWithDenyList(t *testing.T) {
 					Password:  "REDACTED",
 					password:  "REDACTED",
 					byteSlice: []byte("password"),
+					stringPtr: func() *string {
+						password := "password"
+
+						return &password
+					}(),
 				},
 			},
 		},

--- a/rere_test.go
+++ b/rere_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // I think constants make test data harder to glance
 package rere_test
 
 import (
@@ -6,6 +7,11 @@ import (
 	"github.com/dustinspecker/rere"
 	"github.com/onsi/gomega"
 	"github.com/qdm12/reprint"
+)
+
+const (
+	redacted  = "REDACTED"
+	rawString = "raw string"
 )
 
 type structWithoutRedactedFields struct {
@@ -48,6 +54,27 @@ type structWithInterface struct {
 	password any
 }
 
+type structWithEverything struct {
+	RawString   string
+	rawString   string
+	StringPtr   *string
+	stringPtr   *string
+	StringSlice []string
+	stringSlice []string
+	ByteSlice   []byte
+	byteSlice   []byte
+	Number      int
+	number      int
+	NumberPtr   *int
+	numberPtr   *int
+	StructSlice []structWithRedactedFields
+	structSlice []structWithRedactedFields
+}
+
+type complexStructHolder struct {
+	NestedStruct *structWithEverything
+}
+
 //nolint:funlen,maintidx // I'm okay with test functions with several statements of test data
 func TestRedactWithAllowList(t *testing.T) {
 	t.Parallel()
@@ -80,10 +107,10 @@ func TestRedactWithAllowList(t *testing.T) {
 			},
 			allowList: nil,
 			output: structWithRedactedFields{
-				Username:  "REDACTED",
-				username:  "REDACTED",
-				Password:  "REDACTED",
-				password:  "REDACTED",
+				Username:  redacted,
+				username:  redacted,
+				Password:  redacted,
+				password:  redacted,
 				byteSlice: nil,
 				stringPtr: nil,
 			},
@@ -100,10 +127,10 @@ func TestRedactWithAllowList(t *testing.T) {
 			},
 			allowList: nil,
 			output: &structWithRedactedFields{
-				Username:  "REDACTED",
-				username:  "REDACTED",
-				Password:  "REDACTED",
-				password:  "REDACTED",
+				Username:  redacted,
+				username:  redacted,
+				Password:  redacted,
+				password:  redacted,
 				byteSlice: nil,
 				stringPtr: nil,
 			},
@@ -146,8 +173,8 @@ func TestRedactWithAllowList(t *testing.T) {
 			},
 			allowList: nil,
 			output: structWithByteSlice{
-				Password: []byte("REDACTED"),
-				password: []byte("REDACTED"),
+				Password: []byte(redacted),
+				password: []byte(redacted),
 			},
 		},
 		{
@@ -169,7 +196,7 @@ func TestRedactWithAllowList(t *testing.T) {
 					Username:  "username",
 					username:  "username",
 					Password:  "password",
-					password:  "REDACTED",
+					password:  redacted,
 					byteSlice: nil,
 					stringPtr: nil,
 				},
@@ -177,10 +204,10 @@ func TestRedactWithAllowList(t *testing.T) {
 			allowList: nil,
 			output: structWithNestedStruct{
 				Nested: structWithRedactedFields{
-					Username:  "REDACTED",
-					username:  "REDACTED",
-					Password:  "REDACTED",
-					password:  "REDACTED",
+					Username:  redacted,
+					username:  redacted,
+					Password:  redacted,
+					password:  redacted,
 					byteSlice: nil,
 					stringPtr: nil,
 				},
@@ -190,25 +217,25 @@ func TestRedactWithAllowList(t *testing.T) {
 			name:      "handles maps",
 			input:     map[string]string{"password": "password"},
 			allowList: nil,
-			output:    map[string]string{"password": "REDACTED"},
+			output:    map[string]string{"password": redacted},
 		},
 		{
 			name:      "handles strings",
 			input:     "password",
 			allowList: nil,
-			output:    "REDACTED",
+			output:    redacted,
 		},
 		{
 			name:      "handles arrays",
 			input:     [1]string{"some_value"},
 			allowList: nil,
-			output:    [1]string{"REDACTED"},
+			output:    [1]string{redacted},
 		},
 		{
 			name:      "handles slices",
 			input:     []string{"password"},
 			allowList: nil,
-			output:    []string{"REDACTED"},
+			output:    []string{redacted},
 		},
 		{
 			name: "handles complex struct",
@@ -231,10 +258,10 @@ func TestRedactWithAllowList(t *testing.T) {
 				NestedStructs: []structWithNestedStruct{
 					{
 						Nested: structWithRedactedFields{
-							Username:  "REDACTED",
-							username:  "REDACTED",
-							Password:  "REDACTED",
-							password:  "REDACTED",
+							Username:  redacted,
+							username:  redacted,
+							Password:  redacted,
+							password:  redacted,
 							byteSlice: nil,
 							stringPtr: nil,
 						},
@@ -246,7 +273,7 @@ func TestRedactWithAllowList(t *testing.T) {
 			name: "handles nested pointers",
 			input: structWithNestedPointer{
 				Password: func() **string {
-					redacted := "REDACTED"
+					redacted := redacted
 					redactedPointer := &redacted
 
 					return &redactedPointer
@@ -255,7 +282,7 @@ func TestRedactWithAllowList(t *testing.T) {
 			allowList: nil,
 			output: structWithNestedPointer{
 				Password: func() **string {
-					redacted := "REDACTED"
+					redacted := redacted
 					redactedPointer := &redacted
 
 					return &redactedPointer
@@ -270,8 +297,8 @@ func TestRedactWithAllowList(t *testing.T) {
 			},
 			allowList: nil,
 			output: structWithInterface{
-				Password: "REDACTED",
-				password: "REDACTED",
+				Password: redacted,
+				password: redacted,
 			},
 		},
 		{
@@ -305,7 +332,7 @@ func TestRedactWithAllowList(t *testing.T) {
 			output: map[string]string{
 				"Username": "dustin",
 				"username": "dustin",
-				"Password": "REDACTED",
+				"Password": redacted,
 			},
 		},
 		{
@@ -325,12 +352,33 @@ func TestRedactWithAllowList(t *testing.T) {
 				Nested: structWithRedactedFields{
 					Username:  "username",
 					username:  "username",
-					Password:  "REDACTED",
-					password:  "REDACTED",
+					Password:  redacted,
+					password:  redacted,
 					byteSlice: []byte("password"),
 					stringPtr: nil,
 				},
 			},
+		},
+		{
+			name:      "redacts everything by default",
+			input:     getComplexStruct(),
+			allowList: nil,
+			output:    getRedactedComplexStruct(),
+		},
+		{
+			name:  "can avoid redacting everything included in allow list",
+			input: getComplexStruct(),
+			allowList: []string{
+				"RawString",
+				"StringPtr",
+				"StringSlice",
+				"ByteSlice",
+				"Number",
+				"NumberPtr",
+				"username",
+				"password",
+			},
+			output: getComplexStruct(),
 		},
 	}
 
@@ -365,13 +413,13 @@ func TestRedactWithDenyList(t *testing.T) {
 			name:     "redacts simple []byte value",
 			input:    []byte("hello"),
 			denyList: nil,
-			output:   []byte("REDACTED"),
+			output:   []byte(redacted),
 		},
 		{
 			name:     "redacts simple string value",
 			input:    "hello",
 			denyList: nil,
-			output:   "REDACTED",
+			output:   redacted,
 		},
 		{
 			name: "redacts only field names in deny list regardless of case",
@@ -387,8 +435,8 @@ func TestRedactWithDenyList(t *testing.T) {
 			output: structWithRedactedFields{
 				Username:  "username",
 				username:  "username",
-				Password:  "REDACTED",
-				password:  "REDACTED",
+				Password:  redacted,
+				password:  redacted,
 				byteSlice: nil,
 				stringPtr: nil,
 			},
@@ -403,8 +451,8 @@ func TestRedactWithDenyList(t *testing.T) {
 			denyList: []string{"password"},
 			output: map[string]string{
 				"Username": "username",
-				"Password": "REDACTED",
-				"password": "REDACTED",
+				"Password": redacted,
+				"password": redacted,
 			},
 		},
 		{
@@ -428,8 +476,8 @@ func TestRedactWithDenyList(t *testing.T) {
 				Nested: structWithRedactedFields{
 					Username:  "username",
 					username:  "username",
-					Password:  "REDACTED",
-					password:  "REDACTED",
+					Password:  redacted,
+					password:  redacted,
 					byteSlice: []byte("password"),
 					stringPtr: func() *string {
 						password := "password"
@@ -438,6 +486,27 @@ func TestRedactWithDenyList(t *testing.T) {
 					}(),
 				},
 			},
+		},
+		{
+			name:     "redacts nothing by default",
+			input:    getComplexStruct(),
+			denyList: nil,
+			output:   getComplexStruct(),
+		},
+		{
+			name:  "can redact every string and []byte included in deny list",
+			input: getComplexStruct(),
+			denyList: []string{
+				"RawString",
+				"StringPtr",
+				"StringSlice",
+				"ByteSlice",
+				"Number",
+				"NumberPtr",
+				"username",
+				"password",
+			},
+			output: getRedactedComplexStruct(),
 		},
 	}
 
@@ -455,5 +524,131 @@ func TestRedactWithDenyList(t *testing.T) {
 			g.Expect(&redacted).ToNot(gomega.BeIdenticalTo(&testCase.input), "RedactWithDenyList should create a deep copy")
 			g.Expect(testCase.input).To(gomega.Equal(originalInput), "RedactWithDenyList should not modify the provided input")
 		})
+	}
+}
+
+func getComplexStruct() complexStructHolder {
+	return complexStructHolder{
+		NestedStruct: &structWithEverything{
+			RawString: rawString,
+			rawString: rawString,
+			StringPtr: func() *string {
+				rawString := rawString
+
+				return &rawString
+			}(),
+			stringPtr: func() *string {
+				rawString := rawString
+
+				return &rawString
+			}(),
+			StringSlice: []string{"string slice", "string slice"},
+			stringSlice: []string{"string slice", "string slice"},
+			ByteSlice:   []byte("byte slice"),
+			byteSlice:   []byte("byte slice"),
+			Number:      42,
+			number:      42,
+			NumberPtr: func() *int {
+				number := 42
+
+				return &number
+			}(),
+			numberPtr: func() *int {
+				number := 42
+
+				return &number
+			}(),
+			StructSlice: []structWithRedactedFields{
+				{
+					Username:  "username",
+					username:  "username",
+					Password:  "password",
+					password:  "password",
+					byteSlice: []byte("password"),
+					stringPtr: func() *string {
+						password := "password"
+
+						return &password
+					}(),
+				},
+			},
+			structSlice: []structWithRedactedFields{
+				{
+					Username:  "username",
+					username:  "username",
+					Password:  "password",
+					password:  "password",
+					byteSlice: []byte("password"),
+					stringPtr: func() *string {
+						password := "password"
+
+						return &password
+					}(),
+				},
+			},
+		},
+	}
+}
+
+func getRedactedComplexStruct() complexStructHolder {
+	return complexStructHolder{
+		NestedStruct: &structWithEverything{
+			RawString: redacted,
+			rawString: redacted,
+			StringPtr: func() *string {
+				rawString := redacted
+
+				return &rawString
+			}(),
+			stringPtr: func() *string {
+				rawString := redacted
+
+				return &rawString
+			}(),
+			StringSlice: []string{redacted, redacted},
+			stringSlice: []string{redacted, redacted},
+			ByteSlice:   []byte(redacted),
+			byteSlice:   []byte(redacted),
+			Number:      42,
+			number:      42,
+			NumberPtr: func() *int {
+				number := 42
+
+				return &number
+			}(),
+			numberPtr: func() *int {
+				number := 42
+
+				return &number
+			}(),
+			StructSlice: []structWithRedactedFields{
+				{
+					Username:  redacted,
+					username:  redacted,
+					Password:  redacted,
+					password:  redacted,
+					byteSlice: []byte(redacted),
+					stringPtr: func() *string {
+						password := redacted
+
+						return &password
+					}(),
+				},
+			},
+			structSlice: []structWithRedactedFields{
+				{
+					Username:  redacted,
+					username:  redacted,
+					Password:  redacted,
+					password:  redacted,
+					byteSlice: []byte(redacted),
+					stringPtr: func() *string {
+						password := redacted
+
+						return &password
+					}(),
+				},
+			},
+		},
 	}
 }

--- a/rere_test.go
+++ b/rere_test.go
@@ -410,16 +410,16 @@ func TestRedactWithDenyList(t *testing.T) {
 		output   any
 	}{
 		{
-			name:     "redacts simple []byte value",
+			name:     "does not redact simple []byte value",
 			input:    []byte("hello"),
 			denyList: nil,
-			output:   []byte(redacted),
+			output:   []byte("hello"),
 		},
 		{
-			name:     "redacts simple string value",
+			name:     "does not redact simple string value",
 			input:    "hello",
 			denyList: nil,
-			output:   redacted,
+			output:   "hello",
 		},
 		{
 			name: "redacts only field names in deny list regardless of case",


### PR DESCRIPTION
- move logic to determine whether to redact or not to string and slice cases
   - this fixes a number of edge cases
 - make `RedactWithDenyList` the opposite of `RedactWithAllowList` regarding when a user directly provides a `string` or `[]byte` type